### PR TITLE
Allow for longer student IDs and fix crash when students forget to logout

### DIFF
--- a/src/main/java/activities/UserActivity.java
+++ b/src/main/java/activities/UserActivity.java
@@ -237,7 +237,7 @@ public class UserActivity {
         int mentorIdLength = LocalDbActivity.kIdLengthFallback;
 
         try {
-            Integer.parseInt(userID);
+            Long.parseLong(userID);
 
             if (Constants.kMentorFallback) {
                 return userID.length() == idLength || userID.length() == mentorIdLength;

--- a/src/main/java/activities/UserActivity.java
+++ b/src/main/java/activities/UserActivity.java
@@ -182,7 +182,7 @@ public class UserActivity {
             boolean err = false;
 
             if (diffHours < 0) {
-                LoggingUtils.log(Level.SEVERE, "Well this is awkward, difference shouldn't be negative: " + diffHours + diffMinutes + diffSeconds);
+                LoggingUtils.log(Level.SEVERE, "Well this is awkward, difference shouldn't be negative: h:" + diffHours + " m:"+ diffMinutes + " s:"+diffSeconds);
                 err = true;
             }
 
@@ -196,9 +196,7 @@ public class UserActivity {
                 diffMinutes = 60 - Math.abs(diffMinutes);
             }
 
-            String totalTimeFromDifference = String.format("%02d:%02d:%02d", diffHours, diffMinutes, diffSeconds);
 
-            LocalTime totalHoursTime = LocalTime.parse(totalTimeFromDifference);
 
             if (loginTime.getYear() == logoutTime.getYear()) {
                 if (loginTime.getMonth() == logoutTime.getMonth()) {
@@ -213,6 +211,9 @@ public class UserActivity {
             }
 
             if (!err) {
+				String totalTimeFromDifference = String.format("%02d:%02d:%02d", diffHours, diffMinutes, diffSeconds);
+				LocalTime totalHoursTime = LocalTime.parse(totalTimeFromDifference);
+				
                 logoutActivity.logoutUserWithHours(userID, userRow, totalHoursTime, totalTimeFromDifference);
             }
 
@@ -231,7 +232,7 @@ public class UserActivity {
 
     }
 
-    //checks if ID is valid integer and 6 digit number
+    //checks if ID is valid long and x digit number (x based on config file)
     public boolean isValidID(String userID) {
         int idLength = LocalDbActivity.kIdLength;
         int mentorIdLength = LocalDbActivity.kIdLengthFallback;


### PR DESCRIPTION
Our school uses 14 digit bar codes on student cards.  A pretty minor change but it might help someone else without the capacity to change and rebuild it themselves.